### PR TITLE
Fix: Enhance AI Chatbot Interface and Functionality

### DIFF
--- a/templates/chatbot_interface.html
+++ b/templates/chatbot_interface.html
@@ -23,7 +23,7 @@
         border-radius: 4px;
     }
     #chatHistory {
-        height: 400px;
+        height: 370px; /* Reduced height */
         overflow-y: auto;
         padding: 15px;
         border-top: 1px solid #eee;
@@ -53,7 +53,7 @@
     .input-area {
         display: flex;
         align-items: center;
-        padding: 12px;
+        padding: 8px 12px; /* Reduced top/bottom padding */
         background-color: #fff;
     }
     #userInput {
@@ -109,6 +109,7 @@
 
 <div class="chat-container">
     <h1 style="text-align: center; padding: 15px; margin:0; background-color:skyblue; color:white; font-size:1.8rem;">AI 챗봇 상담</h1>
+    <a href="/home" id="homeBtn" class="chat-btn" style="position: absolute; top: 20px; left: 20px; text-decoration: none;">홈</a>
 
     <video id="webcamFeed" autoplay playsinline muted></video> <!-- Added muted to avoid feedback loop if mic is open -->
 
@@ -208,6 +209,9 @@
 
             toggleMicBtn.addEventListener('click', () => {
                 if (!isRecognizing) {
+                    if (speechSynthesis.speaking) { // Added this line
+                        speechSynthesis.cancel();     // Added this line
+                    }                                 // Added this line
                     try {
                         recognition.start();
                     } catch (e) {
@@ -367,8 +371,13 @@
         // 7. Initial Setup
         setupWebcam();
         const initialBotMessage = "안녕하세요! 늘봄이입니다. 무엇을 도와드릴까요?";
-        appendMessage('bot', initialBotMessage);
+        if (chatHistory.children.length === 0) { // Added this condition
+            appendMessage('bot', initialBotMessage);
+        }
         // Speak after a slight delay to allow user interaction/page loading
+        // The speak function should still be called, as the user wants to hear the message.
+        // If the problem was hearing it twice, that would be a different issue (e.g., in speak() or multiple calls).
+        // The request is about the "대사" (line/dialogue) appearing twice, implying visual.
         setTimeout(() => speak(initialBotMessage), 500);
 
     });


### PR DESCRIPTION
This commit addresses four specific requests you made to improve the AI chatbot interface:

1.  **Add Home Button**: A "Home" button has been added to the AI chatbot 상담 창 (`chatbot_interface.html`). This button allows you to easily navigate back to the main page (`/home`).

2.  **Adjust Message Input Position**: The CSS in `chatbot_interface.html` has been modified to move the message input field slightly higher, improving its accessibility and layout. This was achieved by reducing the height of the chat history area and the padding of the input area.

3.  **Stop Speech on Voice Input**: The JavaScript for the voice input button (`toggleMicBtn`) in `chatbot_interface.html` now includes functionality to cancel any ongoing speech synthesis (`speechSynthesis.cancel()`) before attempting to start new voice recognition. This prevents overlapping audio outputs.

4.  **Prevent Duplicate Welcome Message**: A condition has been added to the JavaScript in `chatbot_interface.html` to ensure that the initial welcome message ("안녕하세요! 늘봄이입니다. 무엇을 도와드릴까요?") is visually appended to the chat history only if the history is empty. This prevents the message from appearing multiple times on the screen.