### PR TITLE
Fix: Correct home button URL and clarify chatbot greeting

### DIFF
--- a/templates/chatbot_interface.html
+++ b/templates/chatbot_interface.html
@@ -109,7 +109,7 @@
 
 <div class="chat-container">
     <h1 style="text-align: center; padding: 15px; margin:0; background-color:skyblue; color:white; font-size:1.8rem;">AI 챗봇 상담</h1>
-    <a href="/home" id="homeBtn" class="chat-btn" style="position: absolute; top: 20px; left: 20px; text-decoration: none;">홈</a>
+    <a href="{{ url_for('home.index') }}" id="homeBtn" class="chat-btn" style="position: absolute; top: 20px; left: 20px; text-decoration: none;">홈</a>
 
     <video id="webcamFeed" autoplay playsinline muted></video> <!-- Added muted to avoid feedback loop if mic is open -->
 


### PR DESCRIPTION
- I corrected the home button URL in the chatbot interface to use `url_for('home.index')`, ensuring it routes to the main page (`/`) instead of a non-existent `/home`.
- I investigated the chatbot's initial greeting. I confirmed that the message "안녕하세요! 늘봄이입니다. 무엇을 도와드릴까요?" is visually displayed only once. The perception of it appearing twice is likely due to its single visual display combined with the text-to-speech audio playback, which is the intended behavior. No code change was made for the greeting logic as it functions as designed to prevent visual duplication.