### PR TITLE
feat: Implement PDF certificate generation

### DIFF
--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -1,0 +1,113 @@
+# Manual Testing Procedure for Certificate Generation
+
+This document outlines the manual testing steps for the certificate (prescription and medical confirmation) generation feature.
+
+## Pre-requisites for Manual Testing
+
+1.  **Application Running**: Ensure the Flask application is running. This is typically done by executing `python run.py` from the project's root directory. The application should be accessible at `http://127.0.0.1:5001/`.
+2.  **Dependencies Installed**: Ensure all Python dependencies, including `fpdf2`, are installed. This can usually be done by running `pip install -r requirements.txt`.
+3.  **Korean Font File**:
+    *   A Korean TrueType font file (e.g., `NanumGothic.ttf`) must be placed at `app/static/fonts/NanumGothic.ttf`.
+    *   If this font file is missing or not accessible, the PDF generation will attempt to use a fallback font (Arial). In this case, Korean characters will likely not render correctly, and a warning message should appear at the top of the generated PDF.
+
+## Test Steps
+
+**Important Note**: Clear browser session/cache or use an incognito window between test cases that require a clean session state (like Test Case 3) to avoid interference from previous session data.
+
+---
+
+**Test Case 1: Full successful flow for "처방전" (Prescription PDF)**
+
+*Objective: Verify the successful generation of a prescription PDF with correct data after completing the full user journey through reception and payment.*
+
+1.  **Navigate to Reception**: Open a web browser and go to `http://127.0.0.1:5001/reception`.
+2.  **Input Patient Details**:
+    *   Choose the "직접 입력" (manual input) option.
+    *   Enter a test name (e.g., "김환자").
+    *   Enter a test RRN (e.g., "920202-1234567").
+    *   Click "다음" (Next).
+3.  **Select Symptom**:
+    *   Select a symptom that maps to a department with available prescriptions in `data/treatment_fees.csv`. For example, select "기침‧가래" (which should map to "호흡기내과" or similar).
+    *   Click "다음" (Next). A temporary ticket will be issued; note the department.
+4.  **Navigate to Payment**: Go to `http://127.0.0.1:5001/payment/`.
+5.  **Load Prescriptions**:
+    *   Click the "처방 불러오기" (Load Prescriptions) button.
+    *   **Verify**: Prescriptions related to the selected department should appear on the page, along with a total fee.
+6.  **Navigate to Certificate Menu**: Go to `http://127.0.0.1:5001/certificate/`.
+7.  **Request Prescription PDF**: Click the "처방전 발급" (Issue Prescription) button.
+8.  **Expected Outcome**:
+    *   A PDF document should open in the browser or be downloaded.
+    *   **Filename**: Check that the filename is in the format `prescription_{RRN_PREFIX}_{TIMESTAMP}.pdf` (e.g., `prescription_920202_20231027_103000.pdf`).
+    *   **Content Verification**:
+        *   **Institution Name**: "중앙대 보건소" should be displayed prominently.
+        *   **Patient Information**: The name ("김환자") and RRN ("920202-1234567") should be correct.
+        *   **Department**: The selected department (e.g., "호흡기내과") should be listed.
+        *   **Prescriptions**: The same prescriptions and total fee loaded in step 5 should be itemized correctly.
+        *   **Korean Text**: All Korean text (titles, labels, patient data, prescription names) should be rendered correctly (requires the NanumGothic font).
+        *   **Date**: The current date should be displayed as the issue date.
+
+---
+
+**Test Case 2: Full successful flow for "진료확인서" (Medical Confirmation PDF)**
+
+*Objective: Verify the successful generation of a medical confirmation PDF with correct data.*
+
+1.  **Establish Session**: Ensure patient details (name, RRN) and department are in the session. This can be achieved by completing steps 1-3 of **Test Case 1**.
+2.  **Navigate to Certificate Menu**: Go to `http://127.0.0.1:5001/certificate/`.
+3.  **Request Confirmation PDF**: Click the "진료확인서 발급" (Issue Medical Confirmation) button.
+4.  **Expected Outcome**:
+    *   A PDF document should open in the browser or be downloaded.
+    *   **Filename**: Check that the filename is in the format `medical_confirmation_{RRN_PREFIX}_{TIMESTAMP}.pdf` (e.g., `medical_confirmation_920202_20231027_103500.pdf`).
+    *   **Content Verification**:
+        *   **Institution Name**: "중앙대 보건소" should be displayed.
+        *   **Patient Information**: The name ("김환자") and RRN ("920202-1234567") from the session should be correct.
+        *   **Disease Name ("병명")**: This should be the department name stored in the session (e.g., "호흡기내과").
+        *   **Confirmation Text**: Standard confirmation text should be present.
+        *   **Korean Text**: All Korean text should be rendered correctly.
+        *   **Date**: The current date should be displayed as the issue date.
+
+---
+
+**Test Case 3: Missing Patient Information (Direct Access to Certificate Routes)**
+
+*Objective: Verify that users are redirected to reception if they try to access certificate generation without prior patient information in the session.*
+
+1.  **Prepare Clean Session**: Use a new browser incognito window or clear session cookies for `127.0.0.1:5001`.
+2.  **Navigate to Certificate Menu**: Go to `http://127.0.0.1:5001/certificate/`.
+3.  **Attempt Prescription PDF**: Click "처방전 발급".
+4.  **Expected Outcome**: The user should be redirected to the reception page (`http://127.0.0.1:5001/reception` or similar, possibly with an error query parameter like `?error=patient_info_missing`).
+5.  **Attempt Confirmation PDF**: (Assuming still on certificate page, or navigate back if redirected) Click "진료확인서 발급".
+6.  **Expected Outcome**: The user should be redirected to the reception page (`http://127.0.0.1:5001/reception` or similar, possibly with an error query parameter).
+
+---
+
+**Test Case 4: Missing Department/Prescription Data for "처방전" (Skipping Payment Load or Department without Items)**
+
+*Objective: Verify redirection or appropriate handling if prescription data cannot be loaded for a "처방전". This specifically tests the logic in `app/routes/certificate.py`'s `generate_prescription_pdf` route when `_load_prescription_data` returns no items or an error.*
+
+1.  **Establish Partial Session**: Complete steps 1-3 of **Test Case 1** to get patient name, RRN, and department into the session.
+    *   *Alternative for testing no items*: If possible, temporarily modify `data/treatment_fees.csv` so the selected department has no listed items, or ensure a department is chosen for which no items exist.
+2.  **Navigate Directly to Certificate Menu**: Go to `http://127.0.0.1:5001/certificate/` (crucially, *skip* the `/payment/` page and its "처방 불러오기" step).
+3.  **Attempt Prescription PDF**: Click "처방전 발급".
+4.  **Expected Outcome**:
+    *   The user should be redirected to the payment page (`http://127.0.0.1:5001/payment/`, possibly with an error query parameter like `?error=no_prescription_items`). This is because the `prescription_info` in `certificate.py` would be empty or indicate an issue, triggering the redirect.
+
+---
+
+## General Checks for all Generated PDFs
+
+For every PDF generated during the tests, perform the following checks:
+
+*   **Korean Text Rendering**:
+    *   If `NanumGothic.ttf` is correctly installed: All Korean text (static labels, dynamic data) must be displayed clearly and correctly.
+    *   If `NanumGothic.ttf` is *not* installed: A warning message about the missing font should appear at the top of the PDF. Other text might render in Arial, and Korean characters will likely be broken/missing.
+*   **Dynamic Data Accuracy**:
+    *   Confirm that all pieces of dynamic information (patient name, RRN, selected department/disease name, prescription item names, individual fees, total fees, issue dates) are accurate as per the input or session data.
+*   **Static Text Presence**:
+    *   Confirm that static text elements like the institution name ("중앙대 보건소"), doctor's name ("김중앙"), and other standard phrases are present as expected.
+*   **Layout and Formatting**:
+    *   Check for any obvious layout issues, overlapping text, or formatting errors.
+
+---
+
+This concludes the manual testing procedure. Report any deviations from expected outcomes as bugs.

--- a/app/routes/certificate.py
+++ b/app/routes/certificate.py
@@ -1,42 +1,149 @@
-"""
-증명서 발급 (Blueprint)
-  • GET  /certificate/  → 입력 폼
-  • POST /certificate/  → 발급 완료 화면
-"""
-import uuid
-from flask import Blueprint, render_template, request
+import os
+import csv
+import random
+import io # Will be used for BytesIO for PDF generation
+from datetime import datetime # For filename timestamp
+from flask import (
+    Blueprint, render_template, request, session, redirect, url_for, jsonify, Response
+)
+from app.utils.pdf_generator import generate_prescription_pdf as create_prescription_pdf_bytes
+from app.utils.pdf_generator import generate_medical_confirmation_pdf as create_confirmation_pdf_bytes
 
-# ──────────────────────────────────────────────────────────
-# Blueprint 인스턴스를 'certificate_bp'라는 이름으로 노출
-# ──────────────────────────────────────────────────────────
-certificate_bp = Blueprint("certificate", __name__, url_prefix="/certificate")
+certificate_bp = Blueprint(
+    "certificate", __name__, url_prefix="/certificate", template_folder="../../templates"
+)
 
-# 간단한 인-메모리 저장소 (데모 용도)
-issued_certs: list[dict] = []
+# Data Paths
+BASE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+)
+TREATMENT_FEES_CSV = os.path.join(BASE_DIR, "data", "treatment_fees.csv")
+
+# Helper function to load prescription data
+def _load_prescription_data(department: str) -> dict | None:
+    """
+    Loads prescription data for a given department from TREATMENT_FEES_CSV.
+    Selects 2-3 random prescriptions and calculates the total fee.
+    Returns a dict with 'prescriptions' and 'total_fee', or None if error.
+    """
+    if not os.path.exists(TREATMENT_FEES_CSV):
+        print(f"Error: {TREATMENT_FEES_CSV} not found.")
+        return None
+
+    department_prescriptions = []
+    try:
+        with open(TREATMENT_FEES_CSV, newline="", encoding="utf-8") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                if row["department"].strip() == department:
+                    department_prescriptions.append(
+                        {"name": row["item_name"], "fee": int(row["fee"])}
+                    )
+    except Exception as e:
+        print(f"Error reading or parsing {TREATMENT_FEES_CSV}: {e}")
+        return None
+
+    if not department_prescriptions:
+        print(f"No prescriptions found for department: {department}")
+        return {"prescriptions": [], "total_fee": 0} # Return empty if no specific items
+
+    num_to_select = random.randint(2, 3)
+    if len(department_prescriptions) < num_to_select:
+        selected_prescriptions = department_prescriptions
+    else:
+        selected_prescriptions = random.sample(department_prescriptions, num_to_select)
+
+    total_fee = sum(item["fee"] for item in selected_prescriptions)
+
+    return {"prescriptions": selected_prescriptions, "total_fee": total_fee}
 
 
-@certificate_bp.route("/", methods=["GET", "POST"])
+@certificate_bp.route("/", methods=["GET"])
 def certificate():
     """
-    증명서 발급 액션
+    Renders the main certificate choice page.
     """
-    if request.method == "POST":
-        patient_id      = request.form["patient_id"]
-        cert_type       = request.form["cert_type"]        # diagnosis | visit | vaccination
-        payment_method  = request.form["payment_method"]   # cash | card | qr
+    return render_template("certificate.html")
 
-        cert_no = uuid.uuid4().hex[:8].upper()
-        issued_certs.append(
-            {"no": cert_no, "patient": patient_id, "type": cert_type}
-        )
 
-        return render_template(
-            "certificate.html",
-            step="done",
-            cert_no=cert_no,
-            cert_type=cert_type,
-            payment_method=payment_method,
-        )
+@certificate_bp.route("/prescription/", methods=["GET"])
+def generate_prescription_pdf():
+    """
+    Generates a prescription PDF (currently returns JSON).
+    """
+    patient_name = session.get("patient_name")
+    patient_rrn = session.get("patient_rrn")
+    department = session.get("department")
 
-    # GET 요청 → 입력 폼 렌더링
-    return render_template("certificate.html", step="form")
+    if not patient_name or not patient_rrn:
+        # If basic patient info is missing, redirect to reception
+        return redirect(url_for("reception.reception", error="patient_info_missing"))
+
+    if not department:
+        # If department info is missing (needed for prescriptions), also redirect
+        # Potentially pass an error message to reception or a general error page
+        return redirect(url_for("reception.reception", error="department_info_missing"))
+
+    prescription_info = _load_prescription_data(department)
+
+    if prescription_info is None or not prescription_info["prescriptions"]:
+        # This could happen if CSV is missing, dept not found, or no items for dept.
+        # Redirecting to payment, as per instruction, though this might be confusing.
+        # A better UX might be to show an error on the certificate page itself
+        # or guide the user more clearly.
+        # For now, let's consider if there's a way to inform payment page.
+        # Or, redirect back to reception if the issue is fundamental like unknown dept.
+        # If department exists but has no items, that's a specific case.
+        # Let's redirect to payment and it can handle "no items".
+        return redirect(url_for("payment.payment", error="no_prescription_items"))
+
+
+    # Generate PDF
+    pdf_bytes = create_prescription_pdf_bytes(
+        patient_name=patient_name,
+        patient_rrn=patient_rrn,
+        department=department,
+        prescriptions=prescription_info["prescriptions"],
+        total_fee=prescription_info["total_fee"]
+    )
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"prescription_{patient_rrn.split('-')[0]}_{timestamp}.pdf"
+
+    return Response(
+        io.BytesIO(pdf_bytes),
+        mimetype='application/pdf',
+        headers={'Content-Disposition': f'inline;filename={filename}'}
+    )
+
+
+@certificate_bp.route("/medical_confirmation/", methods=["GET"])
+def generate_confirmation_pdf():
+    """
+    Generates a medical confirmation PDF (currently returns JSON).
+    """
+    patient_name = session.get("patient_name")
+    patient_rrn = session.get("patient_rrn")
+    department = session.get("department") # Used as "병명" (diagnosis/reason for visit)
+
+    if not patient_name or not patient_rrn:
+        return redirect(url_for("reception.reception", error="patient_info_missing"))
+
+    if not department: # Department is essential for "병명"
+        return redirect(url_for("reception.reception", error="department_info_missing_for_confirmation"))
+
+    # Generate PDF
+    pdf_bytes = create_confirmation_pdf_bytes(
+        patient_name=patient_name,
+        patient_rrn=patient_rrn,
+        disease_name=department # department is used as disease_name
+    )
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"medical_confirmation_{patient_rrn.split('-')[0]}_{timestamp}.pdf"
+
+    return Response(
+        io.BytesIO(pdf_bytes),
+        mimetype='application/pdf',
+        headers={'Content-Disposition': f'inline;filename={filename}'}
+    )

--- a/app/routes/reception.py
+++ b/app/routes/reception.py
@@ -60,6 +60,8 @@ def reception():
         # 1) 주민등록증 인식 ---------------------------------------------------
         if action == "scan":
             name, rrn = fake_scan_rrn()
+            session['patient_name'] = name
+            session['patient_rrn'] = rrn
             resv = lookup_reservation(name, rrn)
             if resv:   # 예약 O → 안내
                 return render_template("reception.html", step="reserved",
@@ -72,6 +74,8 @@ def reception():
         if action == "manual":
             name = request.form.get("name", "").strip()
             rrn  = request.form.get("rrn",  "").strip()
+            session['patient_name'] = name
+            session['patient_rrn'] = rrn
             if not name or not rrn:
                 return render_template("reception.html", step="input",
                                        err="이름과 주민번호를 모두 입력하세요.")

--- a/app/utils/pdf_generator.py
+++ b/app/utils/pdf_generator.py
@@ -1,0 +1,119 @@
+from fpdf import FPDF
+import os
+from datetime import datetime
+
+# Define path for a Korean font file.
+# Assumes NanumGothic.ttf will be placed in static/fonts/
+FONT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'static', 'fonts'))
+os.makedirs(FONT_DIR, exist_ok=True) # Ensure the directory exists
+KOREAN_FONT_PATH = os.path.join(FONT_DIR, "NanumGothic.ttf")
+
+def _add_korean_font(pdf_instance):
+    """Helper function to add Korean font to the PDF instance."""
+    try:
+        if os.path.exists(KOREAN_FONT_PATH):
+            pdf_instance.add_font("NanumGothic", "", KOREAN_FONT_PATH, uni=True)
+            pdf_instance.set_font("NanumGothic", size=12)
+            return True
+        else:
+            pdf_instance.set_font("Arial", size=10) # Fallback
+            pdf_instance.cell(0, 10, txt="Korean font (NanumGothic.ttf) not found in static/fonts/. Korean text may not display correctly.", ln=True, align="C")
+            return False
+    except Exception as e:
+        pdf_instance.set_font("Arial", size=10) # Fallback
+        pdf_instance.cell(0, 10, txt=f"Error loading font: {str(e)}. Korean text may not display correctly.", ln=True, align="C")
+        return False
+
+def generate_prescription_pdf(patient_name, patient_rrn, department, prescriptions, total_fee):
+    pdf = FPDF()
+    pdf.add_page()
+    _add_korean_font(pdf)
+
+    # Title
+    pdf.set_font_size(20)
+    pdf.cell(0, 15, txt="처방전 (Prescription)", ln=True, align="C")
+    pdf.ln(5)
+
+    # Header Information
+    pdf.set_font_size(12)
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    pdf.cell(0, 7, txt=f"발행일: {current_date}", ln=True, align="R")
+    pdf.cell(0, 7, txt="기관명: 중앙대 보건소", ln=True)
+    pdf.cell(0, 7, txt=f"환자 성명: {patient_name}", ln=True)
+    pdf.cell(0, 7, txt=f"주민등록번호: {patient_rrn}", ln=True)
+    pdf.cell(0, 7, txt=f"진료과: {department}", ln=True)
+    pdf.ln(5)
+
+    # Prescriptions Table Header
+    pdf.set_font_size(14)
+    pdf.cell(0, 10, txt="처방내역", ln=True)
+    pdf.set_font_size(11) # Slightly smaller for table content
+    pdf.cell(130, 10, txt="처방명 (항목)", border=1)
+    pdf.cell(50, 10, txt="금액 (원)", border=1, ln=True, align="R")
+
+    # Prescriptions Table Rows
+    if prescriptions:
+        for item in prescriptions:
+            # Ensure text fits, potentially use multi_cell if names are very long
+            pdf.cell(130, 10, txt=str(item.get("name", "N/A")), border=1)
+            pdf.cell(50, 10, txt=f"{item.get('fee', 0):,.0f}", border=1, ln=True, align="R")
+    else:
+        pdf.cell(180, 10, txt="처방 내역이 없습니다.", border=1, ln=True, align="C")
+
+    # Total Fee
+    pdf.set_font_size(12)
+    pdf.cell(130, 10, txt="총계 (Total Fee)", border=1, align="R")
+    pdf.cell(50, 10, txt=f"{total_fee:,.0f}", border=1, ln=True, align="R")
+    pdf.ln(10)
+
+    # Footer/Notes
+    pdf.set_font_size(10)
+    pdf.multi_cell(0, 7, txt="위와 같이 처방합니다.\n\n\n의사명: 김중앙 (서명/날인)")
+    pdf.ln(5)
+    pdf.cell(0, 7, txt="* 이 처방전은 발행일로부터 7일간 유효합니다.", ln=True)
+
+
+    return pdf.output(dest='S').encode('latin-1')
+
+def generate_medical_confirmation_pdf(patient_name, patient_rrn, disease_name):
+    pdf = FPDF()
+    pdf.add_page()
+    _add_korean_font(pdf)
+
+    # Title
+    pdf.set_font_size(20)
+    pdf.cell(0, 15, txt="진료확인서 (Medical Confirmation)", ln=True, align="C")
+    pdf.ln(5)
+
+    # Information
+    pdf.set_font_size(12)
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    pdf.cell(0, 7, txt=f"발행일: {current_date}", ln=True, align="R")
+    pdf.cell(0, 7, txt="기관명: 중앙대 보건소", ln=True)
+    pdf.cell(0, 7, txt=f"환자 성명: {patient_name}", ln=True)
+    pdf.cell(0, 7, txt=f"주민등록번호: {patient_rrn}", ln=True)
+    pdf.cell(0, 7, txt=f"진단명 (병명): {disease_name}", ln=True) # Department used as disease name
+    pdf.ln(10)
+
+    # Confirmation Statement
+    # Using a more detailed confirmation text
+    confirmation_text = (
+        f"상기 환자는 위와 같은 진단명으로 {current_date} 본원에서 진료를 받았음을 확인합니다.\n\n"
+        "This is to confirm that the patient named above received medical treatment at our clinic "
+        f"on {current_date} for the diagnosis mentioned.\n\n"
+        "진료의견: 안정가료 및 처방약 복용 요망.\n"
+        "(Medical Opinion: Rest and medication as prescribed.)"
+    )
+    pdf.multi_cell(0, 7, txt=confirmation_text)
+    pdf.ln(15)
+
+    # Doctor's Confirmation
+    pdf.set_font_size(12)
+    pdf.cell(0, 10, txt="담당의사: 김중앙 (Dr. Kim, Joongang)", ln=True, align="R")
+    pdf.cell(0, 10, txt="중앙대학교 보건소 (CAU Health Center)", ln=True, align="R")
+    pdf.ln(5)
+    # Placeholder for stamp/signature image if available
+    # pdf.image("path/to/stamp.png", x=pdf.get_x() + 120, y=pdf.get_y() -10, w=30)
+
+
+    return pdf.output(dest='S').encode('latin-1')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask>=2.2
 gTTS>=2.3
 google-generativeai
 Pillow
+fpdf2>=2.7.0

--- a/templates/certificate.html
+++ b/templates/certificate.html
@@ -1,34 +1,14 @@
 {% extends "base.html" %}
 {% block title %}증명서 발급{% endblock %}
 {% block content %}
-  {% if step == 'choose' %}
-    <h2>서류 종류 선택</h2>
-    <form method="post">
-      <input type="hidden" name="step" value="choose" />
-      <label><input type="radio" name="doc_type" value="diagnosis" /> 진단서</label><br />
-      <label><input type="radio" name="doc_type" value="confirmation" /> 진료확인서</label><br />
-      <label><input type="radio" name="doc_type" value="vaccine" /> 예방접종증명서</label><br />
-      <button type="submit">다음</button>
-    </form>
-  {% elif step == 'auth' %}
-    <h2>본인 인증</h2>
-    <form method="post">
-      <input type="hidden" name="step" value="auth" />
-      <p>선택한 서류: {{ doc_type }}</p>
-      <button type="submit">인증 완료</button>
-    </form>
-  {% elif step == 'payment' %}
-    <h2>결제 방법 선택</h2>
-    <form method="post">
-      <input type="hidden" name="step" value="payment" />
-      <label><input type="radio" name="pay_method" value="cash" /> 현금</label><br />
-      <label><input type="radio" name="pay_method" value="card" /> 카드</label><br />
-      <label><input type="radio" name="pay_method" value="qr" /> QR결제</label><br />
-      <button type="submit">결제 완료</button>
-    </form>
-  {% elif step == 'complete' %}
-    <h2>출력이 완료되었습니다</h2>
-    <p>서류 및 영수증을 받아가세요.</p>
-    <button onclick="location.href='/'">홈으로</button>
-  {% endif %}
+  <h2>증명서 발급</h2>
+  <div style="text-align: center; margin-top: 50px;">
+      <p>발급받을 증명서 종류를 선택해주세요.</p>
+      <a href="{{ url_for('certificate.generate_prescription_pdf') }}" style="text-decoration: none;">
+          <button style="padding: 20px 40px; font-size: 1.2em; margin: 10px; cursor: pointer;">처방전 발급</button>
+      </a>
+      <a href="{{ url_for('certificate.generate_confirmation_pdf') }}" style="text-decoration: none;">
+          <button style="padding: 20px 40px; font-size: 1.2em; margin: 10px; cursor: pointer;">진료확인서 발급</button>
+      </a>
+  </div>
 {% endblock %}


### PR DESCRIPTION
This commit introduces PDF generation for Prescriptions (처방전) and Medical Confirmations (진료확인서) accessible via the /certificate page.

Key changes:

1.  **Reception Update (`app/routes/reception.py`)**:
    *   Patient name and RRN are now stored in the session upon successful
      ID scan or manual input, making them available for certificate
      generation.

2.  **Certificate Page UI (`templates/certificate.html`)**:
    *   The page now displays two buttons: "처방전 발급" (Issue Prescription)
      and "진료확인서 발급" (Issue Medical Confirmation), replacing the
      old multi-step form.

3.  **Certificate Logic (`app/routes/certificate.py`)**:
    *   The main `/certificate/` route now renders the new button UI.
    *   New routes `/certificate/prescription/` and
      `/certificate/medical_confirmation/` handle PDF generation.
    *   These routes fetch patient data from the session.
    *   For prescriptions, data is loaded by reusing the logic from
      `/payment/load_prescriptions` (reading `treatment_fees.csv`
      based on the department in session).
    *   For medical confirmations, the department from the session is used
      as the "병명" (disease name).
    *   Redirects are in place if necessary data (patient info,
      department, prescription data for 처방전) is missing, guiding you
      to `/reception` or `/payment`.

4.  **PDF Generation Utility (`app/utils/pdf_generator.py`)**:
    *   Added `fpdf2` to `requirements.txt`.
    *   Created new utility functions to generate PDFs for prescriptions
      and medical confirmations.
    *   These functions include "중앙대 보건소", patient details, RRN,
      and specific document content (prescription items/fees or
      disease name).
    *   Includes support for Korean text rendering using the NanumGothic
      font (expected at `app/static/fonts/NanumGothic.ttf`), with a
      fallback to Arial and a warning if the font is not found.
    *   PDFs are returned as inline content in the browser.

5.  **Testing**:
    *   Manual testing steps have been documented in `MANUAL_TESTING.md`
      to cover successful flows, error handling for missing data, and
      verification of PDF content including Korean text.