### PR TITLE
Fix csv reading for treatment fees

### DIFF
--- a/app/routes/certificate.py
+++ b/app/routes/certificate.py
@@ -32,12 +32,12 @@ def _load_prescription_data(department: str) -> dict | None:
 
     department_prescriptions = []
     try:
-        with open(TREATMENT_FEES_CSV, newline="", encoding="utf-8") as csvfile:
+        with open(TREATMENT_FEES_CSV, newline="", encoding="utf-8-sig") as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
-                if row["department"].strip() == department:
+                if row["Department"].strip() == department:
                     department_prescriptions.append(
-                        {"name": row["item_name"], "fee": int(row["fee"])}
+                        {"name": row["Prescription"], "fee": int(row["Fee"])}
                     )
     except Exception as e:
         print(f"Error reading or parsing {TREATMENT_FEES_CSV}: {e}")


### PR DESCRIPTION
## Summary
- decode treatment fees CSV using utf-8-sig
- reference actual column names `Department`, `Prescription` and `Fee`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441476fce4832c98a54cf278c9678d