### PR TITLE
Save last prescriptions in session

### DIFF
--- a/app/routes/payment.py
+++ b/app/routes/payment.py
@@ -87,6 +87,10 @@ def load_prescriptions():
 
     total_fee = sum(p["Fee"] for p in selected_prescriptions)
 
+    # Save the generated prescriptions and total fee for later use
+    session["last_prescriptions"] = selected_prescriptions
+    session["last_total_fee"] = total_fee
+
     return jsonify({"prescriptions": selected_prescriptions, "total_fee": total_fee})
 
 


### PR DESCRIPTION
## Summary
- store selected prescriptions and total fee in the session in `/load_prescriptions`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441481de24832c9098398ed94f26a7