### PR TITLE
Improve README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,82 @@
 # Barrier-Free Kiosk Software
 
-This is a web-based kiosk application designed for accessibility in public health centers. It includes features such as reception check-in, payment processing, certificate issuance, and an AI-powered chatbot assistant.
+This project provides a sample web kiosk application targeted at public health centers.
+It focuses on accessibility so that visitors of all ages can easily check in,
+make payments, print certificates and interact with an AI assistant.
+
+## Features
+
+- **Reception** – scan or manually enter resident registration information and
+  receive a ticket number.
+- **Payment** – simple payment form that loads recommended prescriptions from
+  `data/treatment_fees.csv` and records payment details.
+- **Certificate Issuance** – generates PDF prescriptions and medical
+  confirmations. Korean text in the PDFs requires the NanumGothic font.
+- **AI Chatbot** – powered by Google Gemini to answer common questions.
+- **Adjustable Font Size** and basic language support (Korean/English).
 
 ## Installation
 
-1.  **Prerequisites:**
-    *   Python 3.8 or newer is recommended.
-    *   Access to a terminal or command prompt.
-    *   `NanumGothic.ttf` placed in `app/static/fonts/` for proper Korean text rendering in generated PDFs.
+1. **Prerequisites**
+   - Python 3.8 or newer.
+   - A terminal or command prompt.
+   - A TrueType font file `NanumGothic.ttf` placed in
+     `app/static/fonts/` so PDF output shows Korean correctly.
+     The system package `fonts-nanum` on Ubuntu contains this font or you
+     can download it from <https://hangeul.naver.com/font>.
 
-2.  **Clone the Repository (if applicable):**
-    ```bash
-    git clone https://github.com/example/brfree.git
-    cd brfree
-    ```
-    *(If not cloning, ensure you are in the project's root directory. The project directory is named `brfree` in this example.)*
+2. **Clone the repository**
+   ```bash
+   git clone https://github.com/example/brfree.git
+   cd brfree
+   ```
+   *(If not cloning, make sure the current directory is the project root.)*
 
-3.  **Create and Activate a Virtual Environment (Recommended):**
-    ```bash
-    python -m venv venv
-    ```
-    *   On Windows:
-        ```bash
-        venv\Scripts\activate
-        ```
-    *   On macOS/Linux:
-        ```bash
-        source venv/bin/activate
-        ```
+3. **Create and activate a virtual environment** (recommended)
+   ```bash
+   python -m venv venv
+   ```
+   - On Windows:
+     ```bash
+     venv\Scripts\activate
+     ```
+   - On macOS/Linux:
+     ```bash
+     source venv/bin/activate
+     ```
 
-4.  **Install Dependencies:**
-    Make sure your virtual environment is activated. Then run:
-    ```bash
-    pip install -r requirements.txt
-    ```
+4. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
 
-5.  **Set Environment Variables:**
-    This application uses the Google Gemini API for its AI Chatbot functionality. You need to set an API key for this service.
-    *   **`GEMINI_API_KEY`**: Your API key for Google Gemini.
+5. **Configure environment variables**
+   The AI chatbot uses the Google Gemini API. Set your API key before running:
+   - On Windows (Command Prompt)
+     ```bash
+     set GEMINI_API_KEY=YOUR_API_KEY
+     ```
+   - On Windows (PowerShell)
+     ```bash
+     $env:GEMINI_API_KEY="YOUR_API_KEY"
+     ```
+   - On macOS/Linux
+     ```bash
+     export GEMINI_API_KEY=YOUR_API_KEY
+     ```
+   Replace `YOUR_API_KEY` with the key you obtained from Google.
 
-    You can set this variable in your terminal session before running the app:
-    *   On Windows (Command Prompt):
-        ```bash
-        set GEMINI_API_KEY=YOUR_API_KEY_HERE
-        ```
-    *   On Windows (PowerShell):
-        ```bash
-        $env:GEMINI_API_KEY="YOUR_API_KEY_HERE"
-        ```
-    *   On macOS/Linux:
-        ```bash
-        export GEMINI_API_KEY=YOUR_API_KEY_HERE
-        ```
-    Replace `YOUR_API_KEY_HERE` with your actual Gemini API key. For persistent storage, consider using a `.env` file with a library like `python-dotenv` (though this is not implemented in the current project setup) or setting it in your system's environment variables.
+## Running the Application
 
+After installing dependencies and setting the environment variable, start the
+Flask development server:
+
+```bash
+python run.py
+```
+
+The kiosk will be available at <http://127.0.0.1:5001/>.
+
+When generating PDFs, if `NanumGothic.ttf` is missing you will see a warning in
+the PDF and Korean characters may not render correctly. Ensure the font file is
+present in `app/static/fonts/`.


### PR DESCRIPTION
## Summary
- restore installation guide and add detailed font instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68441a9e5e10832cbdaa4b51375cd8fa