### PR TITLE
Use NanumSquareNeo font for PDFs

### DIFF
--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -7,7 +7,7 @@ This document outlines the manual testing steps for the certificate (prescriptio
 1.  **Application Running**: Ensure the Flask application is running. This is typically done by executing `python run.py` from the project's root directory. The application should be accessible at `http://127.0.0.1:5001/`.
 2.  **Dependencies Installed**: Ensure all Python dependencies, including `fpdf2`, are installed. This can usually be done by running `pip install -r requirements.txt`.
 3.  **Korean Font File**:
-    *   A Korean TrueType font file (e.g., `NanumGothic.ttf`) must be placed at `app/static/fonts/NanumGothic.ttf`.
+    *   A Korean TrueType font file (`NanumSquareNeo-bRg.ttf`) must be placed at `app/static/fonts/NanumSquareNeo/NanumSquareNeo/TTF/NanumSquareNeo-bRg.ttf`.
     *   If this font file is missing or not accessible, the PDF generation will attempt to use a fallback font (Arial). In this case, Korean characters will likely not render correctly, and a warning message should appear at the top of the generated PDF.
 
 ## Test Steps
@@ -43,7 +43,7 @@ This document outlines the manual testing steps for the certificate (prescriptio
         *   **Patient Information**: The name ("김환자") and RRN ("920202-1234567") should be correct.
         *   **Department**: The selected department (e.g., "호흡기내과") should be listed.
         *   **Prescriptions**: The same prescriptions and total fee loaded in step 5 should be itemized correctly.
-        *   **Korean Text**: All Korean text (titles, labels, patient data, prescription names) should be rendered correctly (requires the NanumGothic font).
+        *   **Korean Text**: All Korean text (titles, labels, patient data, prescription names) should be rendered correctly (requires the NanumSquareNeo font).
         *   **Date**: The current date should be displayed as the issue date.
 
 ---
@@ -99,8 +99,8 @@ This document outlines the manual testing steps for the certificate (prescriptio
 For every PDF generated during the tests, perform the following checks:
 
 *   **Korean Text Rendering**:
-    *   If `NanumGothic.ttf` is correctly installed: All Korean text (static labels, dynamic data) must be displayed clearly and correctly.
-    *   If `NanumGothic.ttf` is *not* installed: A warning message about the missing font should appear at the top of the PDF. Other text might render in Arial, and Korean characters will likely be broken/missing.
+    *   If `NanumSquareNeo-bRg.ttf` is correctly installed: All Korean text (static labels, dynamic data) must be displayed clearly and correctly.
+    *   If `NanumSquareNeo-bRg.ttf` is *not* installed: A warning message about the missing font should appear at the top of the PDF. Other text might render in Arial, and Korean characters will likely be broken/missing.
 *   **Dynamic Data Accuracy**:
     *   Confirm that all pieces of dynamic information (patient name, RRN, selected department/disease name, prescription item names, individual fees, total fees, issue dates) are accurate as per the input or session data.
 *   **Static Text Presence**:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ make payments, print certificates and interact with an AI assistant.
 - **Payment** – simple payment form that loads recommended prescriptions from
   `data/treatment_fees.csv` and records payment details.
 - **Certificate Issuance** – generates PDF prescriptions and medical
-  confirmations. Korean text in the PDFs requires the NanumGothic font.
+  confirmations. Korean text in the PDFs requires the NanumSquareNeo font.
 - **AI Chatbot** – powered by Google Gemini to answer common questions.
 - **Adjustable Font Size** and basic language support (Korean/English).
 
@@ -20,10 +20,9 @@ make payments, print certificates and interact with an AI assistant.
 1. **Prerequisites**
    - Python 3.8 or newer.
    - A terminal or command prompt.
-   - A TrueType font file `NanumGothic.ttf` placed in
-     `app/static/fonts/` so PDF output shows Korean correctly.
-     The system package `fonts-nanum` on Ubuntu contains this font or you
-     can download it from <https://hangeul.naver.com/font>.
+   - A TrueType font file `NanumSquareNeo-bRg.ttf` placed in
+     `app/static/fonts/NanumSquareNeo/NanumSquareNeo/TTF/` so PDF output shows Korean correctly.
+     The font is included in this repository under that directory.
 
 2. **Clone the repository**
    ```bash
@@ -77,6 +76,6 @@ python run.py
 
 The kiosk will be available at <http://127.0.0.1:5001/>.
 
-When generating PDFs, if `NanumGothic.ttf` is missing you will see a warning in
+When generating PDFs, if `NanumSquareNeo-bRg.ttf` is missing you will see a warning in
 the PDF and Korean characters may not render correctly. Ensure the font file is
-present in `app/static/fonts/`.
+present in `app/static/fonts/NanumSquareNeo/NanumSquareNeo/TTF/`.

--- a/app/utils/pdf_generator.py
+++ b/app/utils/pdf_generator.py
@@ -7,23 +7,33 @@ class MissingKoreanFontError(FileNotFoundError):
     """Raised when the required Korean font file is not available."""
     pass
 
-# Define path for a Korean font file.
-# Assumes NanumGothic.ttf will be placed in static/fonts/
-FONT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'static', 'fonts'))
-os.makedirs(FONT_DIR, exist_ok=True) # Ensure the directory exists
-KOREAN_FONT_PATH = os.path.join(FONT_DIR, "NanumGothic.ttf")
+# Define path for Korean font files.
+# Uses the NanumSquareNeo family located under static/fonts/NanumSquareNeo/
+FONT_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "static",
+        "fonts",
+        "NanumSquareNeo",
+        "NanumSquareNeo",
+        "TTF",
+    )
+)
+os.makedirs(FONT_DIR, exist_ok=True)  # Ensure the directory exists
+KOREAN_FONT_PATH = os.path.join(FONT_DIR, "NanumSquareNeo-bRg.ttf")
 
 def _add_korean_font(pdf_instance):
-    """Helper function to add Korean font to the PDF instance."""
+    """Helper to add NanumSquareNeo font to the PDF instance."""
     if os.path.exists(KOREAN_FONT_PATH):
-        pdf_instance.add_font("NanumGothic", "", KOREAN_FONT_PATH, uni=True)
-        pdf_instance.set_font("NanumGothic", size=12)
+        pdf_instance.add_font("NanumSquareNeo", "", KOREAN_FONT_PATH, uni=True)
+        pdf_instance.set_font("NanumSquareNeo", size=12)
         return True
     raise MissingKoreanFontError(
         (
-            "Korean font 'NanumGothic.ttf' was not found in app/static/fonts/. "
-            "Install the font (e.g. via 'sudo apt-get install fonts-nanum') or "
-            "place the TTF file in that directory."
+            "Korean font 'NanumSquareNeo-bRg.ttf' was not found in "
+            "app/static/fonts/NanumSquareNeo/NanumSquareNeo/TTF/. "
+            "Ensure the font files are present."
         )
     )
 


### PR DESCRIPTION
## Summary
- use NanumSquareNeo font files when creating PDFs
- update docs to mention the new fonts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68441c6c6824832c8f53778ba393e45e