### PR TITLE
Fix storing prescription names for PDF

### DIFF
--- a/app/routes/payment.py
+++ b/app/routes/payment.py
@@ -88,7 +88,10 @@ def load_prescriptions():
     total_fee = sum(p["Fee"] for p in selected_prescriptions)
 
     # Save the generated prescriptions and total fee for later use
-    session["last_prescriptions"] = selected_prescriptions
+    session["last_prescriptions"] = [
+        {"name": p["Prescription"], "fee": float(p["Fee"])}
+        for p in selected_prescriptions
+    ]
     session["last_total_fee"] = total_fee
 
     return jsonify({"prescriptions": selected_prescriptions, "total_fee": total_fee})


### PR DESCRIPTION
## Summary
- store simplified prescription data in session so PDF generation works

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6844239c70c0832cb80b547d6e572a1f