### PR TITLE
Add reservation status updates

### DIFF
--- a/app/routes/reception.py
+++ b/app/routes/reception.py
@@ -30,7 +30,8 @@ def lookup_reservation(name: str, rrn: str):
                     "department": row["department"],
                     "time":       row["time"],
                     "location":   row["location"],
-                    "doctor":     row["doctor"]
+                    "doctor":     row["doctor"],
+                    "status":     row.get("payment_status", "Pending")
                 }
     return None
 


### PR DESCRIPTION
## Summary
- expose reservation `payment_status` from lookup function
- centralize reservation status modification and reuse from payment/reception flows
- inject reservation status into Gemini prompts
- adapt tests for status transitions

## Testing
- `python test_payment_logic.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68444982a144832c93e8f2a5aa20ba5d