### PR TITLE
Fix: Improve chatbot error reporting by displaying specific AI servic…

### DIFF
--- a/app/routes/chatbot.py
+++ b/app/routes/chatbot.py
@@ -514,7 +514,7 @@ def handle_chatbot_request():
     except Exception as e:
         # General error handling for API calls or other unexpected issues
         # Log the error for server-side review: print(f"Error generating content: {e}")
-        return jsonify({"error": f"Error generating content: {str(e)}", "reply": "죄송합니다. AI 서비스와 통신 중 오류가 발생했습니다."}), 500
+        return jsonify({"error": "Error communicating with AI service", "reply": f"AI 서비스 오류: {str(e)}"}), 500
 
 # Example of how to register this blueprint in app/__init__.py:
 # from .routes.chatbot import chatbot_bp


### PR DESCRIPTION
…e errors

Previously, when communication with the AI service failed, a generic error message was displayed to you.

This change modifies the error handling in the chatbot's backend (`app/routes/chatbot.py`) to capture the specific error message from the AI service (Gemini API) and return it in the `reply` field of the JSON error response.

The frontend (`templates/chatbot_interface.html`) already displays the content of the `reply` field in case of an error, so no frontend changes were necessary.

Now, you will see a more informative error message, like "메시지 전송 실패: AI 서비스 오류: [specific error message from AI service]", which can help in diagnosing issues more effectively.