### PR TITLE
Fix: Convert state tuple to string in chatbot prompt

### DIFF
--- a/app/routes/chatbot.py
+++ b/app/routes/chatbot.py
@@ -391,7 +391,7 @@ def handle_chatbot_request():
         if details:
             current_status = details.get('status')
 
-    state = (
+    state_tuple = (
         f"접수완료:{session.get('reception_complete')}, ",
         f"수납완료:{session.get('payment_complete')}, ",
         f"이름:{name}, ",
@@ -399,8 +399,9 @@ def handle_chatbot_request():
         f"진료과:{session.get('department')}, ",
         f"상태:{current_status}"
     )
+    state_str = "".join(list(state_tuple))
 
-    prompt_parts = [SYSTEM_INSTRUCTION_PROMPT, state, "\n\n사용자 질문:\n"]
+    prompt_parts = [SYSTEM_INSTRUCTION_PROMPT, state_str, "\n\n사용자 질문:\n"]
 
     if base64_image_data:
         try:


### PR DESCRIPTION
The `handle_chatbot_request` function in `app/routes/chatbot.py` was constructing a prompt for the generative AI service. It was including a tuple (`state`) directly in the list of prompt parts. The generative AI service expects strings or Blob objects, not tuples, leading to a `TypeError: Could not create Blob... Got a: <class 'tuple'>`.

This commit fixes the issue by converting the `state` tuple into a single string by joining its elements before adding it to the `prompt_parts` list. This ensures that all parts of the prompt are of a type that the AI service can handle.