### PR TITLE
Refactor: Unpack state tuple into individual prompt parts

### DIFF
--- a/app/routes/chatbot.py
+++ b/app/routes/chatbot.py
@@ -391,17 +391,7 @@ def handle_chatbot_request():
         if details:
             current_status = details.get('status')
 
-    state_tuple = (
-        f"접수완료:{session.get('reception_complete')}, ",
-        f"수납완료:{session.get('payment_complete')}, ",
-        f"이름:{name}, ",
-        f"주민번호:{rrn}, ",
-        f"진료과:{session.get('department')}, ",
-        f"상태:{current_status}"
-    )
-    state_str = "".join(list(state_tuple))
-
-    prompt_parts = [SYSTEM_INSTRUCTION_PROMPT, state_str, "\n\n사용자 질문:\n"]
+    prompt_parts = [SYSTEM_INSTRUCTION_PROMPT]
 
     if base64_image_data:
         try:
@@ -425,10 +415,22 @@ def handle_chatbot_request():
             #     return jsonify({"error": f"Invalid image data: {str(img_e)}"}), 400
 
             image_blob = {"mime_type": mime_type, "data": image_bytes}
-            prompt_parts.insert(1, image_blob) # Insert image before the user question but after system prompt
+            prompt_parts.append(image_blob) # Append image if present
         except Exception as e:
             return jsonify({"error": f"Error processing image data: {str(e)}"}), 400
 
+    state_tuple = (
+        f"접수완료:{session.get('reception_complete')}, ",
+        f"수납완료:{session.get('payment_complete')}, ",
+        f"이름:{name}, ",
+        f"주민번호:{rrn}, ",
+        f"진료과:{session.get('department')}, ",
+        f"상태:{current_status}"
+    )
+    for state_item in state_tuple:
+        prompt_parts.append(state_item)
+
+    prompt_parts.append("\n\n사용자 질문:\n")
     prompt_parts.append(user_question)
 
     try:


### PR DESCRIPTION
Previously, the session state tuple (`state_tuple`) was joined into a single string (`state_str`) and added to the `prompt_parts` for my generative AI model. This was a fix for an earlier TypeError but may have made it difficult for me to parse specific details (like name and RRN) from the concatenated state string.

This commit modifies `app/routes/chatbot.py` to iterate through the `state_tuple` and append each of its string elements as a distinct item to the `prompt_parts` list. This provides a more structured representation of the session state to me.

The `prompt_parts` are now constructed by:
1. Starting with `SYSTEM_INSTRUCTION_PROMPT`.
2. Appending an image blob if present.
3. Appending each string from `state_tuple` individually.
4. Appending the user question separator and your question.

This approach should improve my ability to understand and utilize the session context, particularly for extracting patient details for follow-up actions.